### PR TITLE
Add dns-account-01 challenge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## `2.0.25`
 
 * Add support for profiles extension
+* Add support for dns-account-01 challenge
 
 ## `2.0.24`
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The returned order will contain a list of `Authorization` that need to be comple
 
 Each authorization contains multiple challenges, typically a `dns-01`, `dns-account-01`, and a `http-01` challenge. The applicant is only required to complete one of the challenges.
 
-The `dns-account-01` challenge prefixes the record name with an account-specific label so different clients can validate the same domain concurrently.
+The `dns-account-01` challenge prepends an account-specific label before `_acme-challenge`, producing a record name of the form `_<label>._acme-challenge` so different clients can validate the same domain concurrently.
 
 You can access the challenge you wish to complete using the `#dns`, `#dns_account`, or `#http` methods.
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ To order a new certificate, the client must provide a list of identifiers.
 
 The returned order will contain a list of `Authorization` that need to be completed in other to finalize the order, generally one per identifier.
 
-Each authorization contains multiple challenges, typically a `dns-01` and a `http-01` challenge. The applicant is only required to complete one of the challenges.
+Each authorization contains multiple challenges, typically a `dns-01`, `dns-account-01`, and a `http-01` challenge. The applicant is only required to complete one of the challenges.
 
-You can access the challenge you wish to complete using the `#dns` or `#http` method.
+The `dns-account-01` challenge prefixes the record name with an account-specific label so different clients can validate the same domain concurrently.
+
+You can access the challenge you wish to complete using the `#dns`, `#dns_account`, or `#http` methods.
 
 ```ruby
 order = client.new_order(identifiers: ['example.com'])

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -43,6 +43,7 @@ class Acme::Client::Resources::Authorization
       challenge.is_a?(Acme::Client::Resources::Challenges::DNSAccount01)
     }
   end
+  alias_method :dns_account, :dns_account_01
 
   def to_h
     {

--- a/lib/acme/client/resources/authorization.rb
+++ b/lib/acme/client/resources/authorization.rb
@@ -38,6 +38,12 @@ class Acme::Client::Resources::Authorization
   end
   alias_method :dns, :dns01
 
+  def dns_account_01
+    @dns_account_01 ||= challenges.find { |challenge|
+      challenge.is_a?(Acme::Client::Resources::Challenges::DNSAccount01)
+    }
+  end
+
   def to_h
     {
       url: url,

--- a/lib/acme/client/resources/challenges.rb
+++ b/lib/acme/client/resources/challenges.rb
@@ -4,11 +4,13 @@ module Acme::Client::Resources::Challenges
   require 'acme/client/resources/challenges/base'
   require 'acme/client/resources/challenges/http01'
   require 'acme/client/resources/challenges/dns01'
+  require 'acme/client/resources/challenges/dns_account01'
   require 'acme/client/resources/challenges/unsupported_challenge'
 
   CHALLENGE_TYPES = {
     'http-01' => Acme::Client::Resources::Challenges::HTTP01,
-    'dns-01' => Acme::Client::Resources::Challenges::DNS01
+    'dns-01' => Acme::Client::Resources::Challenges::DNS01,
+    'dns-account-01' => Acme::Client::Resources::Challenges::DNSAccount01
   }
 
   def self.new(client, type:, **arguments)

--- a/lib/acme/client/resources/challenges/dns_account01.rb
+++ b/lib/acme/client/resources/challenges/dns_account01.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Acme::Client::Resources::Challenges::DNSAccount01 < Acme::Client::Resources::Challenges::Base
+  CHALLENGE_TYPE = 'dns-account-01'.freeze
+  RECORD_PREFIX = '_acme-challenge_'.freeze
+  RECORD_TYPE = 'TXT'.freeze
+  DIGEST = OpenSSL::Digest::SHA256
+  BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567'.freeze
+
+  def record_name
+    digest = DIGEST.digest(@client.kid)[0, 10]
+    bits = digest.unpack1('B*')
+    label = bits.scan(/.{5}/).map { |chunk| BASE32_ALPHABET[chunk.to_i(2)] }.join
+    "#{RECORD_PREFIX}#{label}"
+  end
+
+  def record_type
+    RECORD_TYPE
+  end
+
+  def record_content
+    Acme::Client::Util.urlsafe_base64(DIGEST.digest(key_authorization))
+  end
+end
+

--- a/lib/acme/client/resources/challenges/dns_account01.rb
+++ b/lib/acme/client/resources/challenges/dns_account01.rb
@@ -2,7 +2,8 @@
 
 class Acme::Client::Resources::Challenges::DNSAccount01 < Acme::Client::Resources::Challenges::Base
   CHALLENGE_TYPE = 'dns-account-01'.freeze
-  RECORD_PREFIX = '_acme-challenge_'.freeze
+  RECORD_PREFIX = '_'.freeze
+  RECORD_SUFFIX = '._acme-challenge'.freeze
   RECORD_TYPE = 'TXT'.freeze
   DIGEST = OpenSSL::Digest::SHA256
   BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567'.freeze
@@ -11,7 +12,7 @@ class Acme::Client::Resources::Challenges::DNSAccount01 < Acme::Client::Resource
     digest = DIGEST.digest(@client.kid)[0, 10]
     bits = digest.unpack1('B*')
     label = bits.scan(/.{5}/).map { |chunk| BASE32_ALPHABET[chunk.to_i(2)] }.join
-    "#{RECORD_PREFIX}#{label}"
+    "#{RECORD_PREFIX}#{label}#{RECORD_SUFFIX}"
   end
 
   def record_type

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -37,13 +37,10 @@ describe Acme::Client::Resources::Authorization do
     end
 
     it 'returns the DNS account challenge', vcr: { cassette_name: 'authorization_dns_account_challenge' } do
-      challenge = authorization.dns_account_01
+      challenge = authorization.dns_account
       expect(challenge).to be_a(Acme::Client::Resources::Challenges::DNSAccount01)
 
-      digest = OpenSSL::Digest::SHA256.digest(client.kid)[0, 10]
-      alphabet = 'abcdefghijklmnopqrstuvwxyz234567'
-      label = digest.unpack1('B*').scan(/.{5}/).map { |c| alphabet[c.to_i(2)] }.join
-      expect(challenge.record_name).to eq("_acme-challenge_#{label}")
+      expect(challenge.record_name).to eq('_acme-challenge_jn322n6un75fspyf')
 
       expected_content = Acme::Client::Util.urlsafe_base64(
         OpenSSL::Digest::SHA256.digest(challenge.key_authorization)

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -40,7 +40,7 @@ describe Acme::Client::Resources::Authorization do
       challenge = authorization.dns_account
       expect(challenge).to be_a(Acme::Client::Resources::Challenges::DNSAccount01)
 
-      expect(challenge.record_name).to eq('_acme-challenge_jn322n6un75fspyf')
+      expect(challenge.record_name).to eq('_jn322n6un75fspyf._acme-challenge')
 
       expected_content = Acme::Client::Util.urlsafe_base64(
         OpenSSL::Digest::SHA256.digest(challenge.key_authorization)

--- a/spec/cassettes/authorization_dns_account_challenge.yml
+++ b/spec/cassettes/authorization_dns_account_challenge.yml
@@ -1,0 +1,248 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<DIRECTORY_URL>"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 10 Oct 2019 03:08:09 GMT
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "keyChange": "<DIRECTORY_BASE_URL>/rollover-account-key",
+           "meta": {
+              "termsOfService": "data:text/plain,Do%20what%20thou%20wilt"
+           },
+           "newAccount": "<DIRECTORY_BASE_URL>/sign-me-up",
+           "newNonce": "<DIRECTORY_BASE_URL>/nonce-plz",
+           "newOrder": "<DIRECTORY_BASE_URL>/order-plz",
+           "revokeCert": "<DIRECTORY_BASE_URL>/revoke-cert"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Oct 2019 03:08:09 GMT
+- request:
+    method: head
+    uri: "<DIRECTORY_BASE_URL>/nonce-plz"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Replay-Nonce:
+      - 3KJWdBtT-druZyDCS675uQ
+      Date:
+      - Thu, 10 Oct 2019 03:08:09 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 10 Oct 2019 03:08:09 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/sign-me-up"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIm5vbmNlIjoiM0tKV2RCdFQtZHJ1WnlEQ1M2NzV1USIsInVybCI6Imh0dHBzOi8vMTkyLjE2OC41Ni45MzoxNDAwMC9zaWduLW1lLXVwIiwiandrIjp7ImUiOiJBUUFCIiwia3R5IjoiUlNBIiwibiI6InhwWG9BVTRmUGlIM3lNdUFZeEtCcWthYTM2NGRNcTNpSDNUTU9ZSkxZclp5b0tzU29hcmFYbkR0LUVrc3FoYTc1SENmX3NtZmhZVHV2b1p2YXBiSnI4QThSc0hhSkFEdVFnYTNHa1ZTY3g0ZGpLTmxtcmI1a1kyNFI1YndHX2owQWhZSExZbU14QWtRREpYSmtUcmdZSUhxbWNQbFI1VG1tY2RNMGh6Z0hIamJaV2ZpNEVrY2RxLUNPbi1OUGRSTE91Q0VrOUVfSUNuQ1E3dmJqYnFvSUxwa010cG9tbEp1cktwOEJrcThMeDV2eVNINTBCUzAtSG42MHo4UTZMb193Q2F1bGs1dmROdWg0Rm1Yd28ydm1HNjRwQ2ZRd1VDa2drLURyWU4tcUxoYloyXzhQOW1iTmpiRkI2SnZQMDd3WDFPWHpJLWk1SmJzenQ3MHVzU0FkdyJ9fQ","payload":"eyJjb250YWN0IjpbIm1haWx0bzppbmZvQGV4YW1wbGUuY29tIl0sInRlcm1zT2ZTZXJ2aWNlQWdyZWVkIjp0cnVlfQ","signature":"L-MQ9PK9riqiy_QqSakEa7k_8eSjsP1EOoPETn0wb8FPbCYUsZDghRaJItnc3TnwzXhV43ZVjl9FOlEHI-z8jLg2BJdUCmcvEP9nU2cDHZf5ShgqjW-vJGPONGjURqZB4nNJL6dli2a0FGcoy7oeb3EciTLhSJp4g6bTC-HP8Vg-6xnzkMD3pu16UjxxZVpu-GiyY6XfBB9bl9ItBU9zJGvO4NgNJTEEZpoOWQ1E2PX522_jCv2ugGhtIRLtfrXJaq9swzlqPYBbtBwjsF9QmbzYQ6I5FDRqz_egBca0UAJSyXisJId4NZkJp1h9I13LIwYBhnuy-vZpEky_7O_Psg"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Location:
+      - "<DIRECTORY_BASE_URL>/my-account/43"
+      Replay-Nonce:
+      - b0Svm6a8QJiMJaKJozR_Hw
+      Date:
+      - Thu, 10 Oct 2019 03:08:09 GMT
+      Content-Length:
+      - '550'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "status": "valid",
+           "contact": [
+              "mailto:info@example.com"
+           ],
+           "orders": "<DIRECTORY_BASE_URL>/list-orderz/43",
+           "key": {
+              "kty": "RSA",
+              "n": "xpXoAU4fPiH3yMuAYxKBqkaa364dMq3iH3TMOYJLYrZyoKsSoaraXnDt-Eksqha75HCf_smfhYTuvoZvapbJr8A8RsHaJADuQga3GkVScx4djKNlmrb5kY24R5bwG_j0AhYHLYmMxAkQDJXJkTrgYIHqmcPlR5TmmcdM0hzgHHjbZWfi4Ekcdq-COn-NPdRLOuCEk9E_ICnCQ7vbjbqoILpkMtpomlJurKp8Bkq8Lx5vySH50BS0-Hn60z8Q6Lo_wCaulk5vdNuh4FmXwo2vmG64pCfQwUCkgk-DrYN-qLhbZ2_8P9mbNjbFB6JvP07wX1OXzI-i5Jbszt70usSAdw",
+              "e": "AQAB"
+           }
+        }
+    http_version: 
+  recorded_at: Thu, 10 Oct 2019 03:08:09 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/order-plz"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIm5vbmNlIjoiYjBTdm02YThRSmlNSmFLSm96Ul9IdyIsInVybCI6Imh0dHBzOi8vMTkyLjE2OC41Ni45MzoxNDAwMC9vcmRlci1wbHoiLCJraWQiOiJodHRwczovLzE5Mi4xNjguNTYuOTM6MTQwMDAvbXktYWNjb3VudC80MyJ9","payload":"eyJpZGVudGlmaWVycyI6W3sidHlwZSI6ImRucyIsInZhbHVlIjoiZXhhbXBsZS5jb20ifV19","signature":"Dhe5GZ_TxSYBgdrsojvV0C6iYR-V4sboK4M2KRarFKFg3Ca5tNZv50E93PwMWisO2xVm7uy57m34EA1EoJkZHn8zZ1LYvVVP30E26LGqp6WRc69eEY1J24tCeZ15_7Z_xUvo0mRSzroGI2qUtg_I2vyJpaiWYrLWM7CJAQiOzVt7xZQd2NtQO9yO3l1qIplJG0jxRsfElXZ_adnFu6V9Ek5MIEw5u3wuFdWO3ylcYAX34Vywjz3os71Xe2ghMqqMVvSm5vpVV3afsigqE7fKJSpkZtll1IwUZIGp5EEo1kiQ1vqrSk9thP35rR3CKSj3ptoMyz-hy7oE2RzLz9pDFQ"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Location:
+      - "<DIRECTORY_BASE_URL>/my-order/dywUEpcqLPS22GhLxoXRfOcxkzosHuhxw2K8t7tIyLw"
+      Replay-Nonce:
+      - VkrCO1skfinxqRQcbuo9sQ
+      Date:
+      - Thu, 10 Oct 2019 03:08:09 GMT
+      Content-Length:
+      - '382'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "status": "pending",
+           "expires": "2019-10-11T03:08:09Z",
+           "identifiers": [
+              {
+                 "type": "dns",
+                 "value": "example.com"
+              }
+           ],
+           "finalize": "<DIRECTORY_BASE_URL>/finalize-order/dywUEpcqLPS22GhLxoXRfOcxkzosHuhxw2K8t7tIyLw",
+           "authorizations": [
+              "<DIRECTORY_BASE_URL>/authZ/QCX_Vz4oC1k8GCjYRN43blNT8K5rV4p0VvoY75J8gJA"
+           ]
+        }
+    http_version: 
+  recorded_at: Thu, 10 Oct 2019 03:08:09 GMT
+- request:
+    method: post
+    uri: "<DIRECTORY_BASE_URL>/authZ/QCX_Vz4oC1k8GCjYRN43blNT8K5rV4p0VvoY75J8gJA"
+    body:
+      encoding: UTF-8
+      string: '{"protected":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIm5vbmNlIjoiVmtyQ08xc2tmaW54cVJRY2J1bzlzUSIsInVybCI6Imh0dHBzOi8vMTkyLjE2OC41Ni45MzoxNDAwMC9hdXRoWi9RQ1hfVno0b0MxazhHQ2pZUk40M2JsTlQ4SzVyVjRwMFZ2b1k3NUo4Z0pBIiwia2lkIjoiaHR0cHM6Ly8xOTIuMTY4LjU2LjkzOjE0MDAwL215LWFjY291bnQvNDMifQ","payload":"","signature":"BgkkkhsNFugbSTjklqqVA-QSBlbvjxv4ewZ5nQHkqMNuY4NOoNYvLSLZu9W6aU2dgM6-a8Awq6yLYgF3z7W3w3xBj4QElXndbiiPJu6G7JMN9Zb18uUsfyE0-fdWUqADE5IK4bnWK1ZREGw88zlMst_IedIjp2vQXRQ7pXryguWIwxq39bsxuEuIoUxE9HWKkZ1e-SLm5jvTvZdNQepTqM9gpm0eUzIUh89LgObyCcGjfUEaBu2RW53Wj6AxBrhv_Dm0UXqjfBVvEQ71HNv2EjlsjuAI1c2XXDVVH8Y9kQkeE0SuPY-FcB3qEK5IVNEdeZ5fuc7FR7DB0bu1Y13szA"}'
+    headers:
+      User-Agent:
+      - Acme::Client v2.0.4 (https://github.com/unixcharles/acme-client)
+      Content-Type:
+      - application/jose+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - public, max-age=0, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Link:
+      - <<DIRECTORY_URL>>;rel="index"
+      Replay-Nonce:
+      - LmdJFv7popZJvaj_K0zfeg
+      Date:
+      - Thu, 10 Oct 2019 03:08:09 GMT
+      Content-Length:
+      - '874'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "status": "pending",
+           "identifier": {
+              "type": "dns",
+              "value": "example.com"
+           },
+           "challenges": [
+              {
+                 "type": "http-01",
+                 "url": "<DIRECTORY_BASE_URL>/chalZ/I8e-_vulYXpJncBb6QTPy-x32vGVBWYWQNQEfQapJMQ",
+                 "token": "ExaeFyYyEBBdabnoNL-19TS8T6s4MsZSXpVB8QBGDOk",
+                 "status": "pending"
+              },
+              {
+                 "type": "dns-01",
+                 "url": "<DIRECTORY_BASE_URL>/chalZ/TnafAJUtyeMBTIsokZROT2UO1SiN-fG8iGkVqfrYfm4",
+                 "token": "lQ1l1wv24HWBaDP_xlIilALd_c1NDTH2ICiJrLPRJUM",
+                 "status": "pending"
+              },
+              {
+                 "type": "dns-account-01",
+                 "url": "<DIRECTORY_BASE_URL>/chalZ/2DnsAccountChallengeUrl",
+                 "token": "DnFoXLE5GT2u3_w3D8V5SzdJPm9Y1kHmAPMGRYGN9w0",
+                 "status": "pending"
+              },
+              {
+                 "type": "tls-alpn-01",
+                 "url": "<DIRECTORY_BASE_URL>/chalZ/lPUCckLvxFPoSYfvD6VkjlLRYJsvrk6MT5QKJz6CPGA",
+                 "token": "2Er7lvQ6PYO9bD-Wk5uGasMJQR4H1Q-W4Y3rzQX4oeQ",
+                 "status": "pending"
+              }
+           ],
+           "expires": "2019-10-10T04:08:09Z"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Oct 2019 03:08:09 GMT
+recorded_with: VCR 2.9.3

--- a/spec/dns01_spec.rb
+++ b/spec/dns01_spec.rb
@@ -16,5 +16,10 @@ describe Acme::Client::Resources::Challenges::DNS01 do
 
   it { expect(dns01.record_name).to eq('_acme-challenge') }
   it { expect(dns01.record_type).to eq('TXT') }
-  it { expect(dns01.record_content).to be_a(String) }
+
+  it 'returns the digest of the key authorization' do
+    key_authorization = "#{attributes[:token]}.#{client.jwk.thumbprint}"
+    expected = Acme::Client::Util.urlsafe_base64(OpenSSL::Digest::SHA256.digest(key_authorization))
+    expect(dns01.record_content).to eq(expected)
+  end
 end

--- a/spec/dns_account_01_spec.rb
+++ b/spec/dns_account_01_spec.rb
@@ -16,7 +16,7 @@ describe Acme::Client::Resources::Challenges::DNSAccount01 do
   end
 
   it 'returns the account specific record name' do
-    expect(dns_account_01.record_name).to eq('_acme-challenge_ujmmovf2vn55tgye')
+    expect(dns_account_01.record_name).to eq('_ujmmovf2vn55tgye._acme-challenge')
   end
 
   it { expect(dns_account_01.record_type).to eq('TXT') }

--- a/spec/dns_account_01_spec.rb
+++ b/spec/dns_account_01_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Acme::Client::Resources::Challenges::DNSAccount01 do
+  let(:private_key) { generate_private_key }
+  let(:kid) { 'https://example.com/acme/acct/ExampleAccount' }
+  let(:client) do
+    Acme::Client.new(private_key: private_key, directory: DIRECTORY_URL, kid: kid)
+  end
+  let(:attributes) do
+    { status: 'pending', url: 'https://example.com/foo/bar', token: 'example_token' }
+  end
+  let(:dns_account_01) do
+    Acme::Client::Resources::Challenges::DNSAccount01.new(client, **attributes)
+  end
+
+  it 'returns the account specific record name' do
+    expect(dns_account_01.record_name).to eq('_acme-challenge_ujmmovf2vn55tgye')
+  end
+
+  it { expect(dns_account_01.record_type).to eq('TXT') }
+
+  it 'returns the digest of the key authorization' do
+    key_authorization = "#{attributes[:token]}.#{client.jwk.thumbprint}"
+    expected = Acme::Client::Util.urlsafe_base64(OpenSSL::Digest::SHA256.digest(key_authorization))
+    expect(dns_account_01.record_content).to eq(expected)
+  end
+end


### PR DESCRIPTION
This pull request adds support for the new `dns-account-01` challenge type to the ACME client, enabling concurrent domain validation by different clients using account-specific DNS records. The update includes changes to the client library, documentation, and test suite to fully integrate this new challenge type.

### Support for `dns-account-01` challenge

* Added a new challenge class `DNSAccount01` in `lib/acme/client/resources/challenges/dns_account01.rb`, which generates account-specific DNS record names and content for validation.
* Updated challenge type mappings in `lib/acme/client/resources/challenges.rb` to include `dns-account-01` and its associated class.
* Added the `dns_account_01` and `dns_account` methods to `lib/acme/client/resources/authorization.rb` to retrieve the new challenge type from authorizations.

### Documentation updates

* Updated `README.md` to describe the new `dns-account-01` challenge, how it works, and how to access it via `#dns_account`.
* Added a note in `CHANGELOG.md` about support for the `dns-account-01` challenge.

### Test suite enhancements

* Added a dedicated spec file `spec/dns_account_01_spec.rb` to test the behavior of the new challenge class.
* Updated `spec/authorization_spec.rb` to test retrieval and properties of the `dns-account-01` challenge from authorizations.
* Added a VCR cassette `spec/cassettes/authorization_dns_account_challenge.yml` to mock interactions for the new challenge type.
* Improved `spec/dns01_spec.rb` to clarify expected behavior for DNS challenge content digest.## Summary
- support ACME dns-account-01 validation with new DNSAccount01 challenge
- expose `dns_account_01` helper and challenge registration
- document dns-account-01 usage in README and changelog

## Testing
- `bundle install`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68b0b78b57748325841b32cffd95326c